### PR TITLE
Update bucket and key prefix references

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ python -m unittest discover -v -s ./lib -p '*_test.py'
 #### Create Stack
 1. Create an s3 bucket
 1. Upload templates
-    * `cloudformation/cloudformation.json` to `[s3 bucket]/pivotal/cloudfoundry/latest/templates/cloud-formation.template`
-    * `cloudformation/ops-manager.json` to  `[s3 bucket]/pivotal/cloudfoundry/latest/templates/ops-manager.template`
+    * `cloudformation/cloudformation.json` to `[s3 bucket]/quickstart-pivotal-cloudfoundry/templates/cloud-formation.template`
+    * `cloudformation/ops-manager.json` to  `[s3 bucket]/quickstart-pivotal-cloudfoundry/templates/ops-manager.template`
     * Make both templates public
 1. Copy your custom `quickstart.tgz`
-    * `[s3 bucket]/pivotal/cloudfoundry/latest/scripts/quickstart.tgz`
+    * `[s3 bucket]/quickstart-pivotal-cloudfoundry/scripts/quickstart.tgz`
     * Make `quickstart.tgz` public
 1. Download the template `pivotal-cloudfoundry.template` from https://github.com/cf-platform-eng/quickstart-pivotal-cloudfoundry/blob/develop/templates/
     * To PR any changes to `pivotal-cloudfoundry.template`, modify `templates/quickstart-template.j2.yml` 

--- a/ci/pipeline-all-in-one.yml
+++ b/ci/pipeline-all-in-one.yml
@@ -62,7 +62,7 @@ resources:
   source:
     bucket: aws-pcf-quickstart-templates
     region_name: us-west-2
-    versioned_file: pivotal/cloudfoundry/latest/templates/cloud-formation.template
+    versioned_file: quickstart-pivotal-cloudfoundry/templates/cloud-formation.template
     access_key_id: {{s3_access_key_id}}
     secret_access_key: {{s3_secret_access_key}}
 
@@ -71,7 +71,7 @@ resources:
   source:
     bucket: aws-pcf-quickstart-templates
     region_name: us-west-2
-    versioned_file: pivotal/cloudfoundry/latest/templates/ops-manager.template
+    versioned_file: quickstart-pivotal-cloudfoundry/templates/ops-manager.template
     access_key_id: {{s3_access_key_id}}
     secret_access_key: {{s3_secret_access_key}}
 
@@ -80,7 +80,7 @@ resources:
   source:
     bucket: aws-pcf-quickstart-templates
     region_name: us-west-2
-    versioned_file: pivotal/cloudfoundry/latest/templates/pivotal-cloudfoundry.template
+    versioned_file: quickstart-pivotal-cloudfoundry/templates/pivotal-cloudfoundry.template
     access_key_id: {{s3_access_key_id}}
     secret_access_key: {{s3_secret_access_key}}
 
@@ -89,7 +89,7 @@ resources:
   source:
     bucket: aws-pcf-quickstart-templates
     region_name: us-west-2
-    versioned_file: pivotal/cloudfoundry/latest/scripts/quickstart.tgz
+    versioned_file: quickstart-pivotal-cloudfoundry/scripts/quickstart.tgz
     access_key_id: {{s3_access_key_id}}
     secret_access_key: {{s3_secret_access_key}}
 

--- a/ci/pipeline-integration-test-allregion.yml
+++ b/ci/pipeline-integration-test-allregion.yml
@@ -40,7 +40,7 @@ resources:
   source:
     bucket: aws-pcf-quickstart-templates
     region_name: us-west-2
-    versioned_file: pivotal/cloudfoundry/latest/scripts/quickstart.tgz
+    versioned_file: quickstart-pivotal-cloudfoundry/scripts/quickstart.tgz
     access_key_id: {{s3_access_key_id}}
     secret_access_key: {{s3_secret_access_key}}
 
@@ -49,7 +49,7 @@ resources:
   source:
     bucket: aws-pcf-quickstart-templates
     region_name: us-west-2
-    versioned_file: pivotal/cloudfoundry/latest/templates/pivotal-cloudfoundry.template
+    versioned_file: quickstart-pivotal-cloudfoundry/templates/pivotal-cloudfoundry.template
     access_key_id: {{s3_access_key_id}}
     secret_access_key: {{s3_secret_access_key}}
 

--- a/templates/quickstart-template.j2.yml
+++ b/templates/quickstart-template.j2.yml
@@ -192,7 +192,7 @@ Parameters:
     ConstraintDescription: Quick Start bucket name can include numbers, lowercase
       letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen
       (-).
-    Default: quickstart-reference
+    Default: aws-quickstart
     Description: S3 bucket name for the Quick Start assets. This string can include
       numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start
       or end with a hyphen (-).
@@ -201,7 +201,7 @@ Parameters:
     AllowedPattern: ^[0-9a-zA-Z-/]*$
     ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
       uppercase letters, hyphens (-), and forward slash (/).
-    Default: pivotal/cloudfoundry/latest/
+    Default: quickstart-pivotal-cloudfoundry/
     Description: S3 key prefix for the Quick Start assets. Quick Start key prefix
       can include numbers, lowercase letters, uppercase letters, hyphens (-), and
       forward slash (/).


### PR DESCRIPTION
We are migrating all AWS Quick Start assets to a new bucket with new key prefixes. The changes in this PR should address the requirements. After merging, we would need another PR against the aws-quickstart/quickstart-pivotal-cloudfoundry repo.

Thanks!
Santiago